### PR TITLE
added handling for additional shiny functions

### DIFF
--- a/R/code-deshine-callstack.R
+++ b/R/code-deshine-callstack.R
@@ -39,38 +39,59 @@
 #'
 #' scriptgloss:::purge_shiny_code(code)
 #'
-purge_shiny_code <- function(x) {
+purge_shiny_code <- function(x, envir = parent.frame()) {
   if (is.call(x)) {
-      
     # find assignment to the shiny output list and replace with nullary function
-    if (any(as.character(x[[1]]) %in% 
+    if (any(gsub('^shiny:{2,3}', '', as.character(x[[1]])) %in% 
         grep("^render", getNamespaceExports("shiny"), value = TRUE))) {
       x <- match.call(definition = eval(x[[1]]), call = x)
-      x <- call("function", NULL, purge_shiny_code(as.list(x)$expr))
+      x <- call("function", NULL, purge_shiny_code(as.list(x)$expr, envir = envir))
       x
       
     # find reactive({ ... }) calls and convert them to function() { ... }
-    } else if (x[[1]] == 'reactive') {
+    } else if (grepl_expr('^(shiny:{2,3})?reactive$', x[[1]])) {
       x <- match.call(definition = eval(x[[1]]), call = x)
-      call("function", NULL, purge_shiny_code(x$x))
+      call("function", NULL, purge_shiny_code(x$x, envir = envir))
+    
+    # find reactiveValuesToList(...) and convert to list(...)
+    } else if (grepl_expr('^(shiny:{2,3})?reactiveValuesToList$', x[[1]])) {
+      do.call("call", c("list", eval(x, envir = envir)))
+      
+    # find reactiveVal(...) calls and convert them to function() { ... }
+    } else if (x[[1]] == '<-' && is.call(x[[3]]) && grepl_expr('^(shiny:{2,3})?reactiveVal$', x[[3]][[1]])) {
+      val <- eval(call(as.character(x[[2]])), envir = envir)
+      x[[3]] <- call("function", NULL, val)
+      x 
+               
+    # find reactiveValues(...) calls and convert them to list(...)
+    } else if (x[[1]] == '<-' && is.call(x[[3]]) && grepl_expr('^(shiny:{2,3})?reactiveValues$', x[[3]][[1]])) {
+      vals <- reactiveValuesToList(eval(x[[2]], envir = envir))
+      x[[3]] <- do.call("call", c("list", vals))
+      x
       
     # remove observe({ ... }) calls
-    } else if (any(as.character(x[[1]]) %in% 
+    } else if (any(gsub('^shiny:{2,3}', '', as.character(x[[1]])) %in% 
         grep("^observe", getNamespaceExports("shiny"), value = TRUE))) {
       NULL
       
     } else {
       # 'deshine' contents of call stack, removing culled branches (NULLs)s
-      as.call(Filter(Negate(is.null), lapply(x, purge_shiny_code)))
+      as.call(Filter(Negate(is.null), lapply(x, purge_shiny_code, envir = envir)))
     }
   
   } else if (is.expression(x)) 
-    as.expression(purge_shiny_code(x[[1]]))
+    as.expression(purge_shiny_code(x[[1]], envir = envir))
   else if (is.atomic(x) || is.name(x)) 
     x
   else if (is.pairlist(x)) 
-    as.pairlist(lapply(x, purge_shiny_code))
+    as.pairlist(lapply(x, purge_shiny_code, envir = envir))
   else if (is.list(x))
-    lapply(x, purge_shiny_code)
+    lapply(x, purge_shiny_code, envir = envir)
   else stop("Don't know how to handle type ", typeof(x), call. = FALSE)
+}
+
+
+
+grepl_expr <- function(pattern, x, ...) {
+  grepl(pattern, paste0(capture.output(x), collapse = '\n'), ...)
 }

--- a/R/code-generate-static-code.R
+++ b/R/code-generate-static-code.R
@@ -93,7 +93,7 @@ generate_static_code <- function(server, ..., dots = list(),
   # process server code and append global files
   # TODO: purge_shiny_code should convert `callModule` calls to static code,
   #       include handling of `NS` functions
-  srv_body <- purge_shiny_code(srv_body) # remove reactives and observers
+  srv_body <- purge_shiny_code(srv_body, envir = envir) # remove reactives and observers
   
   # pre-empt callModule handling by evaluating custom handlers when possible
   srv_body <- attempt_intialize_callModule_calls(srv_body, envir = envir)

--- a/tests/shinytest/shinytest-reactiveVal/app.R
+++ b/tests/shinytest/shinytest-reactiveVal/app.R
@@ -1,0 +1,21 @@
+ui <- fluidPage(
+  h1("reactiveVal"),
+  actionButton("increment_rv", "Increment reactiveVal"),
+  verbatimTextOutput("reactiveVal"),
+  verbatimTextOutput("reactiveVal_code"))
+
+srv <- function(input, output, session) {
+  rv <- reactiveVal(0)
+  
+  observeEvent(input$increment_rv, rv(rv() + 1))
+  
+  output$reactiveVal <- renderPrint({
+    rv()
+  })
+  
+  output$reactiveVal_code <- renderPrint({
+    cat(scriptgloss:::get_code(srv, "reactiveVal"))
+  })
+}
+
+shinyApp(ui, srv)

--- a/tests/shinytest/shinytest-reactiveValues/app.R
+++ b/tests/shinytest/shinytest-reactiveValues/app.R
@@ -1,0 +1,25 @@
+ui <- fluidPage(
+  h1("reactiveValues"),
+  actionButton("increment_rvs", "Increment reactiveValues"),
+  verbatimTextOutput("reactiveValues"),
+  verbatimTextOutput("reactiveValues_code"))
+
+srv <- function(input, output, session) {
+  rvs <- reactiveValues(a = 1, b = 'a', c = FALSE)
+  
+  observeEvent(input$increment_rvs, {
+    rvs$a <- rvs$a + 1
+    rvs$b <- letters[1:rvs$a]
+    rvs$c <- rvs$a %% 2 == 0
+  })
+  
+  output$reactiveValues <- renderPrint({
+    reactiveValuesToList(rvs)
+  })
+  
+  output$reactiveValues_code <- renderPrint({
+    cat(scriptgloss:::get_code(srv, "reactiveValues"))
+  })
+}
+
+shinyApp(ui, srv)

--- a/tests/shinytest/shinytest-reactiveValuesToList/app.R
+++ b/tests/shinytest/shinytest-reactiveValuesToList/app.R
@@ -1,0 +1,26 @@
+ui <- fluidPage(
+  h1("reactiveValues"),
+  actionButton("increment_rvs", "Increment reactiveValues"),
+  verbatimTextOutput("reactiveValues"),
+  verbatimTextOutput("reactiveValues_code"))
+
+srv <- function(input, output, session) {
+  rvs <- reactiveValues(a = 1, b = 'a', c = FALSE)
+  
+  observeEvent(input$increment_rvs, {
+    rvs$a <- rvs$a + 1
+    rvs$b <- letters[1:rvs$a]
+    rvs$c <- rvs$a %% 2 == 0
+  })
+  
+  output$reactiveValues <- renderPrint({
+    x <- reactiveValuesToList(rvs)
+    x[[1]]
+  })
+  
+  output$reactiveValues_code <- renderPrint({
+    cat(scriptgloss:::get_code(srv, "reactiveValues"))
+  })
+}
+
+shinyApp(ui, srv)

--- a/tests/shinytest/shinytest-show_as_verbatim_text/app.R
+++ b/tests/shinytest/shinytest-show_as_verbatim_text/app.R
@@ -3,17 +3,17 @@ choices = list(
   mtcars = mtcars,
   character_vector = c("lorem", "ipsum", "other", "text"))
 
-ui <- fluidPage(
- selectInput("in_item", 
+ui <- shiny::fluidPage(
+ shiny::selectInput("in_item", 
     NULL, 
     choices = names(choices)),
-  verbatimTextOutput("out_text")
+  shiny::verbatimTextOutput("out_text")
 )
 
 srv <- function(input, output, session) {
-  output$out_text <- renderPrint({
+  output$out_text <- shiny::renderPrint({
     print(choices[[input$in_item]])
   })
 }
 
-shinyApp(ui, srv)
+shiny::shinyApp(ui, srv)

--- a/tests/testthat/test-deshine-reactiveVal.R
+++ b/tests/testthat/test-deshine-reactiveVal.R
@@ -1,0 +1,24 @@
+context("reactiveVal get stripped from shiny code")
+
+test_that("reactiveVal calls get converted to nullary functions", {
+  app_path <- scriptgloss:::shinytest_path("shinytest-reactiveVal")
+  app <- shinytest::ShinyDriver$new(app_path)
+    
+  app$setInputs(increment_rv = "click")
+  app$setInputs(increment_rv = "click")
+  app$setInputs(increment_rv = "click")
+  
+  expect_equal({
+    app$getValue("reactiveVal")
+  }, {
+    capture.output(print(3))
+  })
+  
+  expect_equal({
+    app$getValue("reactiveVal_code")
+  }, {
+    "rv <- function() 3\nrv()"
+  })
+  
+  app$stop()
+})

--- a/tests/testthat/test-deshine-reactiveValues.R
+++ b/tests/testthat/test-deshine-reactiveValues.R
@@ -1,0 +1,26 @@
+context("reactiveValues get stripped from shiny code")
+
+test_that("reactiveValues calls get converted to static lists", {
+  app_path <- scriptgloss:::shinytest_path("shinytest-reactiveValues")
+  app <- shinytest::ShinyDriver$new(app_path)
+    
+  app$setInputs(increment_rvs = "click")
+  app$setInputs(increment_rvs = "click")
+  app$setInputs(increment_rvs = "click")
+  
+  expect_equal({
+    app$getValue("reactiveValues")
+  }, {
+    trimws(paste0(capture.output(print(
+      list(a = 4, b = c('a', 'b', 'c', 'd'), c = TRUE)
+    )), collapse = "\n"))
+  })
+  
+  expect_equal({
+    app$getValue("reactiveValues_code")
+  }, {
+    "list(a = 4, b = c(\"a\", \"b\", \"c\", \"d\"), c = TRUE)"
+  })
+  
+  app$stop()
+})

--- a/tests/testthat/test-deshine-reactiveValuesToList.R
+++ b/tests/testthat/test-deshine-reactiveValuesToList.R
@@ -1,0 +1,27 @@
+context("reactiveValuesToList get stripped from shiny code")
+
+test_that("reactiveValuesToList calls get converted to static lists", {
+  app_path <- scriptgloss:::shinytest_path("shinytest-reactiveValuesToList")
+  app <- shinytest::ShinyDriver$new(app_path)
+    
+  app$setInputs(increment_rvs = "click")
+  app$setInputs(increment_rvs = "click")
+  app$setInputs(increment_rvs = "click")
+  
+  expect_equal({
+    app$getValue("reactiveValues")
+  }, {
+    capture.output(print(4))
+  })
+  
+  expect_equal({
+    app$getValue("reactiveValues_code")
+  }, {
+    paste(lapply(expression(
+      x <- list(a = 4, b = c('a', 'b', 'c', 'd'), c = TRUE),
+      x[[1]]
+    ), capture.output), collapse = "\n")
+  })
+  
+  app$stop()
+})

--- a/tests/testthat/test-reduce_nested_syntax.R
+++ b/tests/testthat/test-reduce_nested_syntax.R
@@ -21,34 +21,34 @@ test_that("reducing syntax works as expected", {
       }
     })
   
-  expect_equal(
-    scriptgloss:::reduce_nested_syntax(quote({{{{{}}}}})), 
-    quote({}))
+  # for whatever reason, putting reduce_nested_syntax in the expect_equal call 
+  # throws an rlang error... unclear why this happens
+  a <- scriptgloss:::reduce_nested_syntax(quote({{{{{}}}}}))
+  b <- quote({})
+  expect_equal(a, b)
   
-  expect_equal(
-    scriptgloss:::reduce_nested_syntax(quote({ f <- function() {{{{{}}}}} })), 
-    quote(f <- function() {}))
+  a <- scriptgloss:::reduce_nested_syntax(quote({ f <- function() {{{{{}}}}} }))
+  b <- quote(f <- function() {})
+  expect_equal(a, b)
   
-  expect_equal(
-    scriptgloss:::reduce_nested_syntax(quote({{{{{ a <- 1 }}}}})), 
-    quote(a <- 1))
+  a <- scriptgloss:::reduce_nested_syntax(quote({{{{{ a <- 1 }}}}}))
+  b <- quote(a <- 1)
+  expect_equal(a, b)
   
-  expect_equal(
-    scriptgloss:::reduce_nested_syntax(quote({ f <- function() {{{{{ a <- 1 }}}}} })), 
-    quote(f <- function() a <- 1))
+  a <- scriptgloss:::reduce_nested_syntax(quote({ f <- function() {{{{{ a <- 1 }}}}} }))
+  b <- quote(f <- function() a <- 1)
+  expect_equal(a, b)
   
-  expect_equal({
-    scriptgloss:::reduce_nested_syntax(q)
-  }, {
-    quote({
-      a <- 1
-      x <- function(a = 1, b = { z <- a; z + 1}, c = z + 1) {
-        quote({
-          a <- 1
-          b <- 2
-        })
-       a <- 2
-      }
-    })
+  a <- scriptgloss:::reduce_nested_syntax(q)
+  b <- quote({
+    a <- 1
+    x <- function(a = 1, b = { z <- a; z + 1}, c = z + 1) {
+      quote({
+        a <- 1
+        b <- 2
+      })
+     a <- 2
+    }
   })
+  expect_equal(a, b)
 })

--- a/tests/testthat/test-show_as_verbatim_text.R
+++ b/tests/testthat/test-show_as_verbatim_text.R
@@ -9,22 +9,25 @@ test_that("an assortment of types match verbatim text output", {
     mtcars = mtcars,
     character_vector = c("lorem", "ipsum", "other", "text"))
   
+  app$setInputs(in_item = names(choices[1]))
+  app$waitFor("out_text")
   expect_equal({
-    app$setInputs(in_item = names(choices[1]))
     app$getValue("out_text")
   }, {
     scriptgloss:::show_as_verbatim_text(choices[[1]])
   })
   
+  app$setInputs(in_item = names(choices[2]))
+  app$waitFor("out_text")
   expect_equal({
-    app$setInputs(in_item = names(choices[2]))
     app$getValue("out_text")
   }, {
     scriptgloss:::show_as_verbatim_text(choices[[2]])
   })
     
+  app$setInputs(in_item = names(choices[3]))
+  app$waitFor("out_text")
   expect_equal({
-    app$setInputs(in_item = names(choices[3]))
     app$getValue("out_text")
   }, {
     scriptgloss:::show_as_verbatim_text(choices[[3]])


### PR DESCRIPTION
Addressing #11

Now handling
* `reactiveVal` calls
* `reactiveValues` calls
* `reactiveValuesToList` calls
* `shiny::*` prefixes to function calls (still assumes any un-namespaced calls (e.g. `reactive({...})`) are all resolving to the shiny functions. 